### PR TITLE
Removes /floor turf check for construction

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -197,9 +197,6 @@
 	if(R.one_per_turf && (locate(R.result_type) in usr.loc))
 		to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
 		return 0
-	if(R.on_floor && !isfloorturf(usr.loc))
-		to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
-		return 0
 	return 1
 
 /obj/item/stack/proc/use(used, transfer = FALSE) // return 0 = borked; return 1 = had enough


### PR DESCRIPTION
Removes a check for /floor turfs under the building_checks procedure. Previously this disallowed construction of walls, airlocks, etc. on /planet turfs as they are not a child of /floor.

:cl: 
del: Removes /floor turf check on proc/building_checks
/:cl:

