### PR TITLE
Changes baseturf for /turf to /planet/dirt

### DIFF
--- a/code/game/turfs/simulated/floor/plating/planet.dm
+++ b/code/game/turfs/simulated/floor/plating/planet.dm
@@ -2,7 +2,6 @@
 /turf/open/planet
   icon = 'icons/turf/floors.dmi'
   icon_state = "grass"
-  baseturf = /turf/open/planet/dirt
   initial_gas_mix = PLANET_DEFAULT_ATMOS
   planetary_atmos = TRUE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -3,7 +3,7 @@
 	level = 1
 
 	var/intact = 1
-	var/turf/baseturf = /turf/open/space
+	var/turf/baseturf = /turf/open/planet/dirt
 
 	var/temperature = T20C
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed
@@ -429,7 +429,7 @@
 		qdel(thing, force=TRUE)
 
 	var/turf/newT = ChangeTurf(turf_type, baseturf_type, FALSE, FALSE, forceop = forceop)
-    
+
 	SSair.remove_from_active(newT)
 	newT.CalculateAdjacentTurfs()
 	SSair.add_to_active(newT,1)


### PR DESCRIPTION
Changes the baseturf for /turf to /turf/open/planet/dirt from the original /open/space. This prevents space turfs appearing when removing non-/planet turfs are removed (when removing plating for example).

:cl:
add: Adds /turf/open/planet/dirt as baseturf for /turf
del: Removes /open/space as baseturf for /turf
/:cl:
