### PR TITLE
Changes default world turf and area to planet/dirt and planet_surface, respectively.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -429,7 +429,7 @@
 		qdel(thing, force=TRUE)
 
 	var/turf/newT = ChangeTurf(turf_type, baseturf_type, FALSE, FALSE, forceop = forceop)
-    
+
 	SSair.remove_from_active(newT)
 	newT.CalculateAdjacentTurfs()
 	SSair.add_to_active(newT,1)

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,6 +1,6 @@
 /world
 	mob = /mob/dead/new_player
-	turf = /turf/open/space/basic
+	turf = /turf/open/planet/dirt
 	area = /area/space
 	view = "15x15"
 	cache_lifespan = 7

--- a/code/world.dm
+++ b/code/world.dm
@@ -1,7 +1,7 @@
 /world
 	mob = /mob/dead/new_player
 	turf = /turf/open/planet/dirt
-	area = /area/space
+	area = /area/planet_surface
 	view = "15x15"
 	cache_lifespan = 7
 	hub = "Exadv1.spacestation13"


### PR DESCRIPTION
This changes the ``/world`` default turf to ``/turf/open/planet/dirt`` and ``area`` to ``/area/planet_surface``. This could help speed things along slightly with any new .dmm files having this turf/area spawn by default.

:cl:
add: /world ``turf = /turf/open/planet/dirt`` and ``area = /area/planet_surface``
remove: /world ``turf = /turf/open/space`` and  ``area = /area/space``
/:cl:
