### PR TITLE
Changes /proc/make_plating() to make /dirt instead

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -115,7 +115,7 @@
 	burnt = 1
 
 /turf/open/floor/proc/make_plating()
-	return ChangeTurf(/turf/open/floor/plating)
+	return ChangeTurf(/turf/open/planet/dirt)
 
 /turf/open/floor/ChangeTurf(new_path)
 	if(!isfloorturf(src))


### PR DESCRIPTION
Resolves issue in https://github.com/Planetfall/PlanetfallSS13/issues/3 by changing the argument of ``ChangeTurf`` within ``/proc/make_plating()`` from ``/turf/open/floor/plating`` to ``/turf/open/planet/dirt``.

``break_tile_to_plating()`` is called whenever an explosion acts on a ``/floor`` turf,  leading to it changing the turf to plating. Turfs of this type are now changed to dirt instead.

This does however make the name of ``/proc/make_plating()`` a bit misleading. I can try and remedy this if this is a merge necessity. 

:cl:
add: Changes argument of ``ChangeTurf`` within ``/proc/make_plating()`` from ``/turf/open/floor/plating`` to ``/turf/open/planet/dirt``.
/:cl:
